### PR TITLE
feat(Table): added break word for cells in lazyload case

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -194,11 +194,16 @@ export const Table = <T extends TableRow>({
       return;
     }
 
-    setInitialColumnWidths(
-      columnsElements.map((el) => {
-        return el.getBoundingClientRect().width;
-      }),
-    );
+    const columnsElementsWidths = columnsElements.map((el) => el.getBoundingClientRect().width);
+
+    setInitialColumnWidths(columnsElementsWidths);
+
+    if (
+      columnsElements[0].getBoundingClientRect().left !==
+      columnsElements[columnsElements.length - 1].getBoundingClientRect().left
+    ) {
+      setResizedColumnWidths(columnsElementsWidths);
+    }
   }, [tableWidth]);
 
   const isSortedByColumn = (column: TableColumn<T>): boolean =>


### PR DESCRIPTION
## Описание изменений

Добавлен break word для ячеек в случае lazy load данных таблицы для того, чтобы таблица не ресайзилась в случае прихода новых длинных данных.

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
